### PR TITLE
docs: use of `venv` over `--break-system-packages` while installing dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,15 @@ Before cloning the repository and running the tool, ensure that you have the fol
      ```bash
      cd jee_counsellor
      ```
-
+- Create a Virtual Environment:                                                                                  
+   ```bash
+    python -m venv myenv
+    ```
+- Activating the virtual environment:
+    ```bash
+     myenv\Scripts\activate
+    ```
+              
 - Install the dependencies:
    - Install the required dependencies using the following command:
      ```bash
@@ -172,7 +180,14 @@ git clone https://github.com/ksauraj/jee_counsellor.git
 ```bash
 cd jee_counsellor
 ```
-
+- Create a Virtual Environment:                                                                                  
+   ```bash
+     python -m venv myenv
+    ```
+- Activating the virtual environment:
+    ```bash
+     source myenv/bin/activate
+    ```
 - Install the dependencies:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -146,12 +146,12 @@ Before cloning the repository and running the tool, ensure that you have the fol
 - Create a Virtual Environment:
    - creating a virtual environment to avoid conflict with os distribution package manager:                                                                                 
        ```bash
-        python -m venv myenv
+        python -m venv venv
        ```
 - Activate the virtual environment:
   -  Activating that venv in the directory:
       ```bash
-       myenv\Scripts\activate
+       venv\Scripts\activate
        ```
               
 - Install the dependencies:
@@ -185,12 +185,12 @@ cd jee_counsellor
 - Create a Virtual Environment:
                                                                                   
  ```bash
-  python -m venv myenv
+  python -m venv venv
   ```
 - Activate the virtual environment:
   
  ```bash
-  source myenv/bin/activate
+  source venv/bin/activate
   ```
 - Install the dependencies:
 

--- a/README.md
+++ b/README.md
@@ -143,14 +143,16 @@ Before cloning the repository and running the tool, ensure that you have the fol
      ```bash
      cd jee_counsellor
      ```
-- Create a Virtual Environment:                                                                                  
-   ```bash
-    python -m venv myenv
-    ```
-- Activating the virtual environment:
-    ```bash
-     myenv\Scripts\activate
-    ```
+- Create a Virtual Environment:
+   - creating a virtual environment to avoid conflict with os distribution package manager:                                                                                 
+       ```bash
+        python -m venv myenv
+       ```
+- Activate the virtual environment:
+  -  Activating that venv in the directory:
+      ```bash
+       myenv\Scripts\activate
+       ```
               
 - Install the dependencies:
    - Install the required dependencies using the following command:
@@ -180,14 +182,16 @@ git clone https://github.com/ksauraj/jee_counsellor.git
 ```bash
 cd jee_counsellor
 ```
-- Create a Virtual Environment:                                                                                  
-   ```bash
-     python -m venv myenv
-    ```
-- Activating the virtual environment:
-    ```bash
-     source myenv/bin/activate
-    ```
+- Create a Virtual Environment:
+                                                                                  
+ ```bash
+  python -m venv myenv
+  ```
+- Activate the virtual environment:
+  
+ ```bash
+  source myenv/bin/activate
+  ```
 - Install the dependencies:
 
 ```bash


### PR DESCRIPTION
fixes #53